### PR TITLE
Update cspell dictionary

### DIFF
--- a/.github/.cspell/project-dictionary.txt
+++ b/.github/.cspell/project-dictionary.txt
@@ -3,4 +3,3 @@ rustdocflags
 rustflags
 rustfmt
 rustup
-SIGINT


### PR DESCRIPTION
"SIGINT" has been added to the default dictionary: https://github.com/streetsidesoftware/cspell-dicts/commit/1aa70168b464bb75213b8b3e5218ce478dbe1014